### PR TITLE
gdal 3.0.2 rebuild 3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-libnetcdf:
-  - 4.8

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler_version:        # [linux]
+  - 11.2.0                 # [linux]
+cxx_compiler_version:      # [linux]
+  - 11.2.0                 # [linux]
+fortran_compiler_version:  # [linux or osx]
+  - 11.2.0                 # [linux or osx]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-c_compiler_version:        # [linux]
-  - 11.2.0                 # [linux]
-cxx_compiler_version:      # [linux]
-  - 11.2.0                 # [linux]
-fortran_compiler_version:  # [linux or osx]
-  - 11.2.0                 # [linux or osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/disable_jpeg12.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win and vc<14 or s390x]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -133,8 +133,10 @@ outputs:
         - zstd
       run:
         - cfitsio
+        - expat  # [win]
         - geotiff
         - giflib  # [not win]
+        - hdf5  # [win]
         - json-c  # [not win]
         - libdap4  # [not win]
         - libiconv  # [win]
@@ -146,9 +148,9 @@ outputs:
         - poppler # [not win]
         - proj
         - tiledb
-        - xz  # [not win or vc>=14]
-        - m2w64-xz  # [win]
         - vs2015_runtime  # [win]
+        - xerces-c  # [win]
+        - xz  # [not win or vc>=14]
         - zlib
     test:
       files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -228,7 +228,7 @@ about:
   summary: |
     GDAL is a translator library for raster and vector geospatial data formats that is released under an
     X/MIT style Open Source license by the Open Source Geospatial Foundation.
-  dev_url: https://gdal.org/api/index.html
+  dev_url: https://github.com/OSGeo/gdal
   doc_url: https://gdal.org/tutorials/index.html
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -175,7 +175,8 @@ outputs:
       ignore_run_exports:
         - openssl
         - hdf5
-      skip: True  # [py>39]
+      # Doesn't build with Python 3.10 on Windows, has never been built before.
+      skip: True  # [py>39 and win]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     # disable 12 bit jpeg on Windows as we aren't using internal jpeg
     - patches/disable_jpeg12.patch  # [win]
     # Fix missing include
-    - patches/include-limits-missing.patch
+    - patches/include-limits-missing.patch  # [linux]
 
 build:
   number: 3
@@ -30,6 +30,7 @@ requirements:
     - make  # [not win]
     - libtool  # [not win]
     - m2-patch  # [win]
+    - patch  # [linux]
   host:
     - cfitsio
     - curl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -148,6 +148,7 @@ outputs:
         - tiledb
         - xz  # [not win or vc>=14]
         - m2w64-xz  # [win]
+        - vs2015_runtime  # [win]
         - zlib
     test:
       files:
@@ -174,6 +175,7 @@ outputs:
       ignore_run_exports:
         - openssl
         - hdf5
+      skip: True  # [py>39]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
 
 build:
   number: 3
-  skip: True  # [win and vc<14 or s390x]
+  skip: True  # [win and vc<14 or s390x or py>39]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -218,12 +218,15 @@ outputs:
         summary: 'Python wrapper for the Geospatial Data Abstraction Library (GDAL)'
 
 about:
-  home: http://www.gdal.org
+  home: https://www.gdal.org
   license: MIT
+  license_family: MIT
   license_file: LICENSE.TXT
   summary: |
     GDAL is a translator library for raster and vector geospatial data formats that is released under an
     X/MIT style Open Source license by the Open Source Geospatial Foundation.
+  dev_url: https://gdal.org/api/index.html
+  doc_url: https://gdal.org/tutorials/index.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
     - patches/multiprocessor.patch  # [win]
     # disable 12 bit jpeg on Windows as we aren't using internal jpeg
     - patches/disable_jpeg12.patch  # [win]
+    # Fix missing include
+    - patches/include-limits-missing.patch
 
 build:
   number: 3

--- a/recipe/patches/include-limits-missing.patch
+++ b/recipe/patches/include-limits-missing.patch
@@ -1,0 +1,11 @@
+diff -urN a/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp b/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp
+--- a/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp	2019-10-28 12:58:37.000000000 +0300
++++ b/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp	2022-06-23 16:36:05.324483080 +0300
+@@ -38,6 +38,7 @@
+ #include <iostream>
+ #include <memory>
+ #include <string>
++#include <limits>
+ 
+ #if ((defined(__sun__) || defined(__FreeBSD__)) && __GNUC__ == 4 && __GNUC_MINOR__ == 8) || defined(__ANDROID__)
+ // gcc 4.8 on Solaris 11.3 or FreeBSD 11 doesn't have std::string


### PR DESCRIPTION
Rebuild using new compiler, against updated base system.

The windows build fails with Python 3.10 (import _gdal fails). Since we never built it for Python 3.10 and this is an old version, it should be OK to skip Python 3.10 on Windows.

* Disabled build for Python 3.10 on Windows
* Added patch by ktietz fixing a missing include
* Updated metadata