### PR TITLE
Building v3.0.2 for Python 3.10 on Win-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     # - patches/backport_1722.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
No changes, simply building v3.0.2 for Python 3.10 on Win-64.