### PR TITLE
Rebuild for Python 3.10 on Win-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/include-limits-missing.patch  # [linux]
 
 build:
-  number: 4
+  number: 5
   # Has never been built for s390x
   skip: True  # [s390x]
   ignore_run_exports:


### PR DESCRIPTION
No changes, simply building v3.0.2 for Python 3.10 on Win-64.