### PR TITLE
PKG-1416 rebuild gdal 3.6.2 against libxml2 2.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://download.osgeo.org/gdal/{{ version }}/gdal-{{ version }}.tar.xz
   sha256: 35f40d2e08061b342513cdcddc2b997b3814ef8254514f0ef1e8bc7aa56cf681
 build:
-  number: 0
+  number: 1
   # never be built on s390x
   skip: True  # [linux and s390x]
   skip: True  # [py<36]
@@ -53,7 +53,7 @@ requirements:
     - libtiff
     - libuuid  # [linux]
     - libwebp-base
-    - libxml2
+    - libxml2 2.10
     - lz4-c
     - openjpeg
     - openssl
@@ -119,7 +119,7 @@ outputs:
         - libtiff
         - libuuid  # [linux]
         - libwebp-base
-        - libxml2
+        - libxml2 2.10
         - lz4-c
         - openjpeg
         - openssl
@@ -214,7 +214,7 @@ outputs:
         - libtiff
         - libuuid  # [linux]
         - libwebp-base
-        - libxml2
+        - libxml2 2.10
         - openjpeg
         - openssl
         - pcre2
@@ -291,7 +291,7 @@ outputs:
         - openssl
         - openjpeg
         - libiconv
-        - libxml2
+        - libxml2 2.10
         - blosc
         - cfitsio
         - expat


### PR DESCRIPTION
Changes:
- Increase build number
- Pin libxml2 to 2.10 where applicable