### PR TITLE
gdal v3.6.2 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,8 +74,6 @@ requirements:
     - xz {{ xz }}
     - zlib {{ zlib }}
     - zstd {{ zstd }}
-  run_constrained:
-    - poppler ==22.12.0
 
 outputs:
   - name: libgdal
@@ -160,8 +158,7 @@ outputs:
         - xz
         - zstd
         - openssl  # exact pin handled through openssl run_exports
-      run_constrained:
-        - poppler ==22.12.0
+        - {{ pin_compatible('poppler', max_pin='x.x') }}
 
     test:
       files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -151,7 +151,6 @@ outputs:
         - libwebp-base
         - libxml2
         - openjpeg
-        - poppler
         - proj
         - qhull
         - tiledb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -157,7 +157,7 @@ outputs:
         - xz
         - zstd
         - openssl  # exact pin handled through openssl run_exports
-        - {{ pin_compatible('poppler', max_pin='x.x') }}
+        - {{ pin_compatible('poppler', max_pin='x.x.x') }}
 
     test:
       files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/ec33f6d6dfe944f59dc5454d01b4d000d9479c02.patch
 
 build:
-  number: 5
+  number: 6
   # never be built on s390x
   skip: True  # [linux and s390x]
   skip: True  # [py<36]
@@ -74,6 +74,8 @@ requirements:
     - xz {{ xz }}
     - zlib {{ zlib }}
     - zstd {{ zstd }}
+  run_constrained:
+    - poppler ==22.12.0
 
 outputs:
   - name: libgdal
@@ -158,6 +160,8 @@ outputs:
         - xz
         - zstd
         - openssl  # exact pin handled through openssl run_exports
+      run_constrained:
+        - poppler ==22.12.0
 
     test:
       files:


### PR DESCRIPTION
gdal v3.6.2 rebuild

**Destination channel:** defaults

### Links

- [PKG-6030](https://anaconda.atlassian.net/browse/PKG-6030) 

### Explanation of changes:

- Bump build number
- Add run_constrained for poppler 

### Steps to re-produce
`conda create -n fiona-test fiona -y`
`conda activate fiona-test`
`python -c "import fiona"`

```
> Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/lundby/miniconda3/envs/fiona-test/lib/python3.12/site-packages/fiona/__init__.py", line 41, in <module>
    from fiona._env import (
ImportError: dlopen(/Users/lundby/miniconda3/envs/fiona-test/lib/python3.12/site-packages/fiona/_env.cpython-312-darwin.so, 0x0002): Library not loaded: @rpath/libpoppler.126.dylib
  Referenced from: <042BC0C2-C636-39C6-8DFD-3580A4847EF8> /Users/lundby/miniconda3/envs/fiona-test/lib/libgdal.32.3.6.2.dylib
  Reason: tried: '/Users/lundby/miniconda3/envs/fiona-test/lib/libpoppler.126.dylib' (no such file), '/Users/lundby/miniconda3/envs/fiona-test/lib/python3.12/site-packages/fiona/../../../libpoppler.126.dylib' (no such file), '/Users/lundby/miniconda3/envs/fiona-test/lib/python3.12/site-packages/fiona/../../../libpoppler.126.dylib' (no such file), '/Users/lundby/miniconda3/envs/fiona-test/bin/../lib/libpoppler.126.dylib' (no such file), '/Users/lundby/miniconda3/envs/fiona-test/bin/../lib/libpoppler.126.dylib' (no such file), '/usr/local/lib/libpoppler.126.dylib' (no such file), '/usr/lib/libpoppler.126.dylib' (no such file, not in dyld cache)
```

### Verify the fix
`conda create -n fiona-test-fix -c https://staging.continuum.io/prefect/fs/gdal-feedstock/pr26/970af4d fiona -y`
`conda activate fiona-test-fix`
`python -c "import fiona"`



[PKG-6030]: https://anaconda.atlassian.net/browse/PKG-6030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ