### PR TITLE
Bump version and build against latest poppler.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@
 set -ex # Abort on error.
 
 # also allow newer symbols (https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk)
-export CXXFLAGS="${CXXFLAGS} -std=c++17 -D_LIBCPP_DISABLE_AVAILABILITY"
+export CXXFLAGS="${CXXFLAGS} -std=c++17 -D_LIBCPP_DISABLE_AVAILABILITY -DHAVE_POPPLER"
 
 mkdir build
 cd build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - patches/ec33f6d6dfe944f59dc5454d01b4d000d9479c02.patch
 
 build:
-  number: 6
+  number: 7
   # never be built on s390x
   skip: True  # [linux and s390x]
   skip: True  # [py<36]
@@ -127,7 +127,7 @@ outputs:
         - openjpeg {{ openjpeg }}
         - openssl {{ openssl }}
         - pcre2
-        - poppler 22.12.0
+        - poppler 24.09.0
         - proj {{ proj }}
         # qhull disabled because of https://github.com/conda-forge/qgis-feedstock/issues/284#issuecomment-1356490896
         # - qhull


### PR DESCRIPTION
gdal v3.6.2 build 7

**Destination channel:**  defaults

### Links

- Relevant PRs:
  - https://github.com/AnacondaRecipes/gdal-feedstock/pull/26

### Explanation of changes:

- Bump build number
- Build against latest version of poppler
