### PR TITLE
gdal 3.6.2: Rebuild libgdal with libtiff 4.7.0 

### DIFF
--- a/.gitignore~
+++ b/.gitignore~
@@ -1,4 +1,0 @@
-*.pyc
-
-build_artifacts
-*.py~

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,11 +4,3 @@ build_parameters:
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-  - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
-  - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137
-  - https://staging.continuum.io/prefect/fs/poppler-feedstock/pr20/8944bdf
-  - https://staging.continuum.io/prefect/fs/geotiff-feedstock/pr12/0a9742a

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,4 +6,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,6 @@ build_parameters:
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -11,3 +11,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853
   - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137
   - https://staging.continuum.io/prefect/fs/poppler-feedstock/pr20/8944bdf
+  - https://staging.continuum.io/prefect/fs/geotiff-feedstock/pr12/0a9742a

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,4 +6,8 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
+  - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
+  - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137
+  - https://staging.continuum.io/prefect/fs/poppler-feedstock/pr20/8944bdf

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,4 +6,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ requirements:
     - libwebp-base
     - libxml2 {{ libxml2 }}
     - lz4-c
-    - openjpeg {{ openjpeg }}
+    - openjpeg 2.5.2
     - openssl {{ openssl }}
     - pcre2
     - poppler 24.09
@@ -120,12 +120,12 @@ outputs:
         - libpng {{ libpng }}
         - libpq 17.0
         - libspatialite
-        - libtiff {{ libtiff }}
+        - libtiff 4.7.0
         - libuuid  # [linux]
         - libwebp-base
         - libxml2 {{ libxml2 }}
         - lz4-c
-        - openjpeg {{ openjpeg }}
+        - openjpeg 2.5.2
         - openssl {{ openssl }}
         - pcre2
         - poppler 24.09
@@ -214,11 +214,11 @@ outputs:
         - libpng {{ libpng }}
         - libpq 17.0
         - libspatialite
-        - libtiff {{ libtiff }}
+        - libtiff 4.7.0
         - libuuid  # [linux]
         - libwebp-base
         - libxml2 {{ libxml2 }}
-        - openjpeg {{ openjpeg }}
+        - openjpeg 2.5.2
         - openssl {{ openssl }}
         - pcre2
         - poppler 24.09
@@ -292,7 +292,7 @@ outputs:
         - openssl {{openssl }}  # Only required to produce all openssl variants.
         - {{ pin_subpackage('libgdal', max_pin='x.x.x', exact=True) }}
         # Without this, the solver is having a hard time resolving the correct dependencies...
-        - openjpeg {{ openjpeg }}
+        - openjpeg 2.5.2
       run:
         - python
         - {{ pin_compatible('numpy') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - libpng {{ libpng }}
     - libpq 17.0
     - libspatialite
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     - libuuid  # [linux]
     - libwebp-base
     - libxml2 {{ libxml2 }}
@@ -120,7 +120,7 @@ outputs:
         - libpng {{ libpng }}
         - libpq 17.0
         - libspatialite
-        - libtiff 4.7.0
+        - libtiff {{ libtiff }}
         - libuuid  # [linux]
         - libwebp-base
         - libxml2 {{ libxml2 }}
@@ -214,7 +214,7 @@ outputs:
         - libpng {{ libpng }}
         - libpq 17.0
         - libspatialite
-        - libtiff 4.7.0
+        - libtiff {{ libtiff }}
         - libuuid  # [linux]
         - libwebp-base
         - libxml2 {{ libxml2 }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0002-c++20-syntax.patch
 
 build:
-  number: 9
+  number: 10
   # never be built on s390x
   skip: True  # [linux and s390x]
   skip: True  # [py<36]
@@ -56,7 +56,7 @@ requirements:
     - libpng {{ libpng }}
     - libpq 17.0
     - libspatialite
-    - libtiff {{ libtiff }}
+    - libtiff 4.7.0
     - libuuid  # [linux]
     - libwebp-base
     - libxml2 {{ libxml2 }}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7591](https://anaconda.atlassian.net/browse/PKG-7591) 
- [Upstream repository](https://github.com/OSGeo/gdal/tree/v3.6.2)

### Explanation of changes:

- Bump the build number to 10
- Pin libtiff in host

### Notes:

-

[PKG-7591]: https://anaconda.atlassian.net/browse/PKG-7591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ