### PR TITLE
Rebuild against libarchive 3.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - patches/000_cmake.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:
@@ -44,7 +44,7 @@ requirements:
     - jpeg {{ jpeg }}
     - json-c 0.16  # [not win]
     - lerc 4.0
-    - libarchive 3.7
+    - libarchive 3.8
     - libcurl {{ libcurl }}
     - libboost-headers {{ libboost }}
     - libdeflate 1.22


### PR DESCRIPTION
gdal 3.11.0 

**Destination channel:** Defaults

### Links

- [PKG-9568]
- dev_url:        https://github.com/OSGeo/gdal/tree/v3.11.0
- conda_forge:    https://github.com/conda-forge/gdal-feedstock
- pypi:           https://pypi.org/project/gdal/3.11.0
- pypi inspector: https://inspector.pypi.io/project/gdal/3.11.0

### Explanation of changes:

- rebuild with libarchive 3.8