### PR TITLE
Rebuild against libxml2 2.15.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,5 @@ c_compiler_version:   # [osx]
   - 17.0.6            # [osx]
 cxx_compiler_version: # [osx]
   - 17.0.6            # [osx]
+libxml2:
+  - 2.15.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/000_cmake.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:


### PR DESCRIPTION
gdal 3.13.0

**Destination channel:** defaults

### Links

- [PKG-15894](https://anaconda.atlassian.net/browse/PKG-15894) 
- [Upstream repository](https://github.com/OSGeo/gdal/tree/v3.13.1)

### Explanation of changes:
- Rebulid against libxm2 2.15.3


[PKG-15894]: https://anaconda.atlassian.net/browse/PKG-15894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ