### PR TITLE
rebuild gdal against libpq 18.4

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,6 @@ cxx_compiler_version: # [osx]
   - 17.0.6            # [osx]
 libxml2:
   - 2.15.3
+# TODO: remove once conda_build_config.yaml pins libpq to 18
+libpq:
+  - 18.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/000_cmake.patch  # [osx]
 
 build:
-  number: 1
+  number: 2
   skip_compile_pyc:
     - share/bash-completion/completions/*.py
   ignore_run_exports_from:


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-15955
- https://gdal.org
- https://github.com/OSGeo/gdal

## Changes
- Pin libpq to 18.4 locally in conda_build_config.yaml to rebuild against the new libpq (root pin not yet bumped to 18).

## Notes
- Local libpq pin should be removed once the root conda_build_config.yaml pins libpq to 18 (see TODO comment in recipe/conda_build_config.yaml).